### PR TITLE
feat: adding stream store and related commands functionality

### DIFF
--- a/src/main/java/org/perfect047/Server.java
+++ b/src/main/java/org/perfect047/Server.java
@@ -7,6 +7,8 @@ import org.perfect047.storage.keyvalue.IKeyValueStore;
 import org.perfect047.storage.keyvalue.KeyValueStore;
 import org.perfect047.storage.listvalue.IListValueStore;
 import org.perfect047.storage.listvalue.ListValueStore;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.storage.streamvalue.StreamValueStore;
 
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -25,7 +27,7 @@ public class Server {
      * Creates the default server with in-memory stores and configured concurrency strategy.
      */
     public Server() {
-        this(new KeyValueStore(), new ListValueStore(), new ConcurrencyFactory());
+        this(new KeyValueStore(), new ListValueStore(), new StreamValueStore(), new ConcurrencyFactory());
     }
 
     /**
@@ -35,8 +37,8 @@ public class Server {
      * @param listValueStore list-value store implementation
      * @param concurrencyFactory factory that selects the connection handling strategy
      */
-    public Server(IKeyValueStore keyValueStore, IListValueStore listValueStore, ConcurrencyFactory concurrencyFactory) {
-        this(new CommandFactory(keyValueStore, listValueStore), concurrencyFactory);
+    public Server(IKeyValueStore keyValueStore, IListValueStore listValueStore, IStreamValueStore streamValueStore, ConcurrencyFactory concurrencyFactory) {
+        this(new CommandFactory(keyValueStore, listValueStore, streamValueStore), concurrencyFactory);
     }
 
     /**

--- a/src/main/java/org/perfect047/Server.java
+++ b/src/main/java/org/perfect047/Server.java
@@ -4,7 +4,7 @@ import org.perfect047.command.CommandFactory;
 import org.perfect047.concurrency.ConcurrencyFactory;
 import org.perfect047.concurrency.IConcurrencyStrategy;
 import org.perfect047.storage.keyvalue.IKeyValueStore;
-import org.perfect047.storage.keyvalue.KeyValueKeyValueStore;
+import org.perfect047.storage.keyvalue.KeyValueStore;
 import org.perfect047.storage.listvalue.IListValueStore;
 import org.perfect047.storage.listvalue.ListValueStore;
 
@@ -25,7 +25,7 @@ public class Server {
      * Creates the default server with in-memory stores and configured concurrency strategy.
      */
     public Server() {
-        this(new KeyValueKeyValueStore(), new ListValueStore(), new ConcurrencyFactory());
+        this(new KeyValueStore(), new ListValueStore(), new ConcurrencyFactory());
     }
 
     /**

--- a/src/main/java/org/perfect047/command/CommandFactory.java
+++ b/src/main/java/org/perfect047/command/CommandFactory.java
@@ -2,6 +2,8 @@ package org.perfect047.command;
 
 import org.perfect047.storage.keyvalue.IKeyValueStore;
 import org.perfect047.storage.listvalue.IListValueStore;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.storage.streamvalue.StreamValueStore;
 
 import java.io.OutputStream;
 import java.util.HashMap;
@@ -15,15 +17,17 @@ public class CommandFactory {
 
     private final IKeyValueStore keyValueStore;
     private final IListValueStore listValueStore;
+    private final IStreamValueStore streamValueStore;
     private final Map<String, Function<OutputStream, ICommand>> commandRegistry = new HashMap<>();
 
     /**
      * @param keyValueStore backing store for key-value commands
      * @param listValueStore backing store for list commands
      */
-    public CommandFactory(IKeyValueStore keyValueStore, IListValueStore listValueStore) {
+    public CommandFactory(IKeyValueStore keyValueStore, IListValueStore listValueStore, IStreamValueStore streamValueStore) {
         this.keyValueStore = keyValueStore;
         this.listValueStore = listValueStore;
+        this.streamValueStore = streamValueStore;
         registerCommands();
     }
 
@@ -38,6 +42,7 @@ public class CommandFactory {
         commandRegistry.put("LLEN", os -> new LLenCommand(os, listValueStore));
         commandRegistry.put("LPOP", os -> new LPopCommand(os, listValueStore));
         commandRegistry.put("BLPOP", os -> new BLPopCommand(os, listValueStore));
+        commandRegistry.put("XADD", os -> new XAddCommand(os, streamValueStore));
     }
 
     public ICommand getCommand(String commandName, OutputStream outputStream) {

--- a/src/main/java/org/perfect047/command/CommandFactory.java
+++ b/src/main/java/org/perfect047/command/CommandFactory.java
@@ -43,6 +43,9 @@ public class CommandFactory {
         commandRegistry.put("LPOP", os -> new LPopCommand(os, listValueStore));
         commandRegistry.put("BLPOP", os -> new BLPopCommand(os, listValueStore));
         commandRegistry.put("XADD", os -> new XAddCommand(os, streamValueStore));
+        commandRegistry.put("XRANGE", os -> new XRangeCommand(os, streamValueStore));
+        commandRegistry.put("XREAD", os -> new XReadCommand(os, streamValueStore));
+        commandRegistry.put("TYPE", os -> new TypeCommand(os, streamValueStore, keyValueStore, listValueStore));
     }
 
     public ICommand getCommand(String commandName, OutputStream outputStream) {

--- a/src/main/java/org/perfect047/command/StoresCommand.java
+++ b/src/main/java/org/perfect047/command/StoresCommand.java
@@ -1,0 +1,28 @@
+package org.perfect047.command;
+
+import org.perfect047.storage.keyvalue.IKeyValueStore;
+import org.perfect047.storage.listvalue.IListValueStore;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+
+import java.io.OutputStream;
+
+public class StoresCommand extends BaseCommand{
+
+    protected final IStreamValueStore streamValueStore;
+    protected final IListValueStore listValueStore;
+    protected final IKeyValueStore keyValueStore;
+
+    /**
+     * @param outputStream stream bound to the current client connection
+     * @param streamValueStore store used by stream commands
+     * @param keyValueStore store used by map commands
+     * @param listValueStore store used by list commands
+     */
+    protected StoresCommand(OutputStream outputStream, IStreamValueStore streamValueStore, IKeyValueStore keyValueStore, IListValueStore listValueStore) {
+        super(outputStream);
+        this.streamValueStore = streamValueStore;
+        this.keyValueStore = keyValueStore;
+        this.listValueStore = listValueStore;
+    }
+
+}

--- a/src/main/java/org/perfect047/command/StreamValueCommand.java
+++ b/src/main/java/org/perfect047/command/StreamValueCommand.java
@@ -10,7 +10,7 @@ public class StreamValueCommand extends BaseCommand{
 
     /**
      * @param outputStream stream bound to the current client connection
-     * @param streamValueStore store used by list commands
+     * @param streamValueStore store used by stream commands
      */
     protected StreamValueCommand(OutputStream outputStream, IStreamValueStore streamValueStore) {
         super(outputStream);

--- a/src/main/java/org/perfect047/command/StreamValueCommand.java
+++ b/src/main/java/org/perfect047/command/StreamValueCommand.java
@@ -1,0 +1,20 @@
+package org.perfect047.command;
+
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+
+import java.io.OutputStream;
+
+public class StreamValueCommand extends BaseCommand{
+
+    protected final IStreamValueStore streamValueStore;
+
+    /**
+     * @param outputStream stream bound to the current client connection
+     * @param streamValueStore store used by list commands
+     */
+    protected StreamValueCommand(OutputStream outputStream, IStreamValueStore streamValueStore) {
+        super(outputStream);
+        this.streamValueStore = streamValueStore;
+    }
+
+}

--- a/src/main/java/org/perfect047/command/TypeCommand.java
+++ b/src/main/java/org/perfect047/command/TypeCommand.java
@@ -1,0 +1,44 @@
+package org.perfect047.command;
+
+import org.perfect047.storage.keyvalue.IKeyValueStore;
+import org.perfect047.storage.listvalue.IListValueStore;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.util.RespString;
+
+import java.io.OutputStream;
+import java.util.List;
+
+public class TypeCommand extends StoresCommand implements ICommand{
+
+    public TypeCommand(OutputStream outputStream, IStreamValueStore streamValueStore, IKeyValueStore keyValueStore, IListValueStore listValueStore) {
+        super(outputStream, streamValueStore,keyValueStore,listValueStore);
+    }
+
+    @Override
+    public void execute(List<String> args) throws Exception {
+
+        if (args.size() < 2) {
+            throw new IllegalArgumentException("TYPE requires key");
+        }
+
+        String key = args.get(1);
+
+        String type = resolveType(key);
+
+        getOutputStream().write(
+                RespString.getRespSimpleString(List.of(type)).getBytes()
+        );
+    }
+
+    /**
+     * Resolves the type of the key across all stores
+     */
+    private String resolveType(String key) {
+
+        String keyType = keyValueStore.type(key);
+        String listType = listValueStore.type(key);
+        String streamType = streamValueStore.type(key);
+
+        return keyType != null ? keyType : listType != null ? listType : streamType;
+    }
+}

--- a/src/main/java/org/perfect047/command/TypeCommand.java
+++ b/src/main/java/org/perfect047/command/TypeCommand.java
@@ -39,6 +39,6 @@ public class TypeCommand extends StoresCommand implements ICommand{
         String listType = listValueStore.type(key);
         String streamType = streamValueStore.type(key);
 
-        return keyType != null ? keyType : listType != null ? listType : streamType;
+        return keyType != null ? keyType : listType != null ? listType : streamType != null ? streamType : "none";
     }
 }

--- a/src/main/java/org/perfect047/command/XAddCommand.java
+++ b/src/main/java/org/perfect047/command/XAddCommand.java
@@ -1,0 +1,47 @@
+package org.perfect047.command;
+
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.util.RespString;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+public class XAddCommand extends StreamValueCommand implements ICommand {
+
+    public XAddCommand(OutputStream outputStream, IStreamValueStore streamValueStore) {
+        super(outputStream, streamValueStore);
+    }
+
+    @Override
+    public void execute(List<String> args) throws IOException {
+
+        try {
+            if (args.size() < 5) {
+                throw new IllegalArgumentException(
+                        "XADD requires key, id and at least one field-value pair"
+                );
+            }
+
+            String streamName = args.get(1);
+            List<String> streamArgs = args.subList(2, args.size());
+
+            if ((streamArgs.size() - 1) % 2 != 0) {
+                throw new IllegalArgumentException(
+                        "XADD field-value pairs must be even"
+                );
+            }
+
+            String id = streamValueStore.add(streamName, streamArgs);
+
+            getOutputStream().write(
+                    RespString.getRespBulkString(List.of(id)).getBytes()
+            );
+
+        } catch (Exception ex) {
+            getOutputStream().write(
+                    RespString.getRespErrorString(ex.getMessage()).getBytes()
+            );
+        }
+    }
+}

--- a/src/main/java/org/perfect047/command/XRangeCommand.java
+++ b/src/main/java/org/perfect047/command/XRangeCommand.java
@@ -27,9 +27,15 @@ public class XRangeCommand extends StreamValueCommand implements ICommand{
 
         List<Object> result = streamValueStore.range(streamName, start, end);
 
-        getOutputStream().write(
-                RespString.getRespArrayString(result).getBytes()
-        );
+        if (result == null || result.isEmpty()) {
+            getOutputStream().write(
+                    RespString.getRespArrayString(List.of()).getBytes()
+            );
+        } else {
+            getOutputStream().write(
+                    RespString.getRespArrayString(result).getBytes()
+            );
+        }
     }
 
 }

--- a/src/main/java/org/perfect047/command/XRangeCommand.java
+++ b/src/main/java/org/perfect047/command/XRangeCommand.java
@@ -1,0 +1,35 @@
+package org.perfect047.command;
+
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.util.RespString;
+
+import java.io.OutputStream;
+import java.util.List;
+
+public class XRangeCommand extends StreamValueCommand implements ICommand{
+
+    public XRangeCommand(OutputStream outputStream, IStreamValueStore streamValueStore){
+        super(outputStream, streamValueStore);
+    }
+
+    @Override
+    public void execute(List<String> args) throws Exception {
+
+        if (args.size() < 4) {
+            throw new IllegalArgumentException(
+                    "XRANGE requires key, start and end"
+            );
+        }
+
+        String streamName = args.get(1);
+        String start = args.get(2);
+        String end = args.get(3);
+
+        List<Object> result = streamValueStore.range(streamName, start, end);
+
+        getOutputStream().write(
+                RespString.getRespArrayString(result).getBytes()
+        );
+    }
+
+}

--- a/src/main/java/org/perfect047/command/XReadCommand.java
+++ b/src/main/java/org/perfect047/command/XReadCommand.java
@@ -1,0 +1,4 @@
+package org.perfect047.command;
+
+public class XReadCommand {
+}

--- a/src/main/java/org/perfect047/command/XReadCommand.java
+++ b/src/main/java/org/perfect047/command/XReadCommand.java
@@ -16,6 +16,10 @@ public class XReadCommand extends StreamValueCommand implements ICommand {
     @Override
     public void execute(List<String> args) throws Exception {
 
+        if (args.size() < 4) {
+            throw new IllegalArgumentException("Invalid XREAD arguments");
+        }
+
         int index = 1;
         long blockTime = -1;
 
@@ -51,12 +55,12 @@ public class XReadCommand extends StreamValueCommand implements ICommand {
 
         for (int i = 0; i < n; i++) {
             String key = keys.get(i);
-            String id  = resolveId(keys.get(i), ids.get(i));
+            String id = resolveId(key, ids.get(i));
 
             List<Object> result = handleReadOrBlock(key, id, blockTime);
 
             if (result != null && !result.isEmpty()) {
-                finalResult.add(result.get(0));
+                finalResult.add(List.of(key, result));
             }
         }
 
@@ -79,7 +83,21 @@ public class XReadCommand extends StreamValueCommand implements ICommand {
      */
     private String resolveId(String key, String id) {
         if ("$".equals(id)) {
-            return streamValueStore.getLastId(key);
+            String lastId = streamValueStore.getLastId(key);
+
+            if (lastId == null) {
+                return "0-0";
+            }
+
+            String[] parts = lastId.split("-");
+            long ms = Long.parseLong(parts[0]);
+            long seq = Long.parseLong(parts[1]);
+
+            if (seq > 0) {
+                return ms + "-" + (seq - 1);
+            } else {
+                return (ms - 1) + "-0";
+            }
         }
         return id;
     }

--- a/src/main/java/org/perfect047/command/XReadCommand.java
+++ b/src/main/java/org/perfect047/command/XReadCommand.java
@@ -1,4 +1,86 @@
 package org.perfect047.command;
 
-public class XReadCommand {
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.util.RespString;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class XReadCommand extends StreamValueCommand implements ICommand {
+
+    public XReadCommand(OutputStream outputStream, IStreamValueStore streamValueStore) {
+        super(outputStream, streamValueStore);
+    }
+
+    @Override
+    public void execute(List<String> args) throws Exception {
+
+        int index = 1;
+        long blockTime = -1;
+
+        // BLOCK parsing
+        if ("BLOCK".equalsIgnoreCase(args.get(index))) {
+            blockTime = Long.parseLong(args.get(index + 1));
+            index += 2;
+        }
+
+        if (!"STREAMS".equalsIgnoreCase(args.get(index))) {
+            throw new IllegalArgumentException("ERR missing STREAMS");
+        }
+
+        index++;
+
+        List<Object> finalResult = handleStreams(args, index, blockTime);
+
+        getOutputStream().write(RespString.getRespArrayString(finalResult).getBytes());
+    }
+
+    /**
+     * Handles STREAMS parsing + iteration
+     */
+    private List<Object> handleStreams(List<String> args, int index, long blockTime) {
+
+        int remaining = args.size() - index;
+        int n = remaining / 2;
+
+        List<String> keys = args.subList(index, index + n);
+        List<String> ids  = args.subList(index + n, args.size());
+
+        List<Object> finalResult = new ArrayList<>();
+
+        for (int i = 0; i < n; i++) {
+            String key = keys.get(i);
+            String id  = resolveId(keys.get(i), ids.get(i));
+
+            List<Object> result = handleReadOrBlock(key, id, blockTime);
+
+            if (result != null && !result.isEmpty()) {
+                finalResult.add(result.get(0));
+            }
+        }
+
+        return finalResult;
+    }
+
+    /**
+     * Handles BLOCK vs non-BLOCK logic
+     */
+    private List<Object> handleReadOrBlock(String key, String id, long blockTime) {
+        if (blockTime >= 0) {
+            return streamValueStore.readBlocking(key, id, blockTime);
+        } else {
+            return streamValueStore.read(key, id);
+        }
+    }
+
+    /**
+     * Resolves special ID cases like "$"
+     */
+    private String resolveId(String key, String id) {
+        if ("$".equals(id)) {
+            return streamValueStore.getLastId(key);
+        }
+        return id;
+    }
 }

--- a/src/main/java/org/perfect047/storage/ITypeStore.java
+++ b/src/main/java/org/perfect047/storage/ITypeStore.java
@@ -1,0 +1,5 @@
+package org.perfect047.storage;
+
+public interface ITypeStore {
+    String type(String key);
+}

--- a/src/main/java/org/perfect047/storage/StoreFactory.java
+++ b/src/main/java/org/perfect047/storage/StoreFactory.java
@@ -1,18 +1,22 @@
 package org.perfect047.storage;
 
 import org.perfect047.storage.keyvalue.IKeyValueStore;
-import org.perfect047.storage.keyvalue.KeyValueKeyValueStore;
+import org.perfect047.storage.keyvalue.KeyValueStore;
 import org.perfect047.storage.listvalue.IListValueStore;
 import org.perfect047.storage.listvalue.ListValueStore;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.storage.streamvalue.StreamValueStore;
 
 public class StoreFactory {
 
     private static final IKeyValueStore keyValueStore;
     private static final IListValueStore listValueStore;
+    private static final IStreamValueStore streamValueStore;
 
     static{
-        keyValueStore = new KeyValueKeyValueStore();
+        keyValueStore = new KeyValueStore();
         listValueStore = new ListValueStore();
+        streamValueStore = new StreamValueStore();
     }
 
     public static IKeyValueStore getKeyValueStore() {
@@ -20,6 +24,9 @@ public class StoreFactory {
     }
     public static IListValueStore getListValueStore() {
         return listValueStore;
+    }
+    public  static IStreamValueStore getStreamValueStore() {
+        return streamValueStore;
     }
 
 }

--- a/src/main/java/org/perfect047/storage/keyvalue/IKeyValueStore.java
+++ b/src/main/java/org/perfect047/storage/keyvalue/IKeyValueStore.java
@@ -1,6 +1,8 @@
 package org.perfect047.storage.keyvalue;
 
-public interface IKeyValueStore {
+import org.perfect047.storage.ITypeStore;
+
+public interface IKeyValueStore extends ITypeStore {
 
     boolean set(String key, String value, Long millis);
 

--- a/src/main/java/org/perfect047/storage/keyvalue/KeyValueStore.java
+++ b/src/main/java/org/perfect047/storage/keyvalue/KeyValueStore.java
@@ -8,7 +8,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * In-memory key-value store with support for key expiration.
  * Handles storage operations with thread-safe access using locks and manages expiry.
  */
-public class KeyValueKeyValueStore implements IKeyValueStore {
+public class KeyValueStore implements IKeyValueStore {
 
     private final ConcurrentMap<String, String> store = new ConcurrentHashMap<>();
     private final LockManager lockManager = new LockManager();

--- a/src/main/java/org/perfect047/storage/keyvalue/KeyValueStore.java
+++ b/src/main/java/org/perfect047/storage/keyvalue/KeyValueStore.java
@@ -68,4 +68,9 @@ public class KeyValueStore implements IKeyValueStore {
             lock.readLock().lock();
         }
     }
+
+    @Override
+    public String type(String key) {
+        return store.get(key) != null ? "string" : null;
+    }
 }

--- a/src/main/java/org/perfect047/storage/listvalue/ConditionManager.java
+++ b/src/main/java/org/perfect047/storage/listvalue/ConditionManager.java
@@ -1,0 +1,32 @@
+package org.perfect047.storage.listvalue;
+
+public class ConditionManager {
+
+    private final java.util.concurrent.ConcurrentMap<String, java.util.concurrent.locks.Condition> conditions = new java.util.concurrent.ConcurrentHashMap<>();
+
+    /**
+     * Gets or creates a condition for the given key using the provided lock.
+     * @param key The key to get the condition for
+     * @param lock The lock to associate the condition with
+     * @return The Condition for this key
+     */
+    public java.util.concurrent.locks.Condition getCondition(String key, java.util.concurrent.locks.ReentrantLock lock) {
+        return conditions.computeIfAbsent(key, k -> lock.newCondition());
+    }
+
+    /**
+     * Removes the condition for a key.
+     * @param key The key to remove the condition for
+     */
+    public void removeCondition(String key) {
+        conditions.remove(key);
+    }
+
+    /**
+     * Clears all conditions.
+     */
+    public void clear() {
+        conditions.clear();
+    }
+
+}

--- a/src/main/java/org/perfect047/storage/listvalue/IListValueStore.java
+++ b/src/main/java/org/perfect047/storage/listvalue/IListValueStore.java
@@ -1,4 +1,5 @@
 package org.perfect047.storage.listvalue;
 
-public interface IListValueStore extends IListWriter, IListReader, IBlockingListReader
-{}
+import org.perfect047.storage.ITypeStore;
+
+public interface IListValueStore extends IListWriter, IListReader, IBlockingListReader, ITypeStore {}

--- a/src/main/java/org/perfect047/storage/listvalue/ListValueStore.java
+++ b/src/main/java/org/perfect047/storage/listvalue/ListValueStore.java
@@ -13,13 +13,13 @@ public class ListValueStore implements IListValueStore {
 
     private static final Logger LOGGER = Logger.getLogger(ListValueStore.class.getName());
     private final ConcurrentMap<String, List<String>> store = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, ReentrantLock> locks = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, Condition> conditions = new ConcurrentHashMap<>();
+    private final LockManager lockManager = new LockManager();
+    private final ConditionManager conditionManager = new ConditionManager();
 
     @Override
     public Integer leftAdd(String listName, List<String> values) {
-        ReentrantLock lock = locks.computeIfAbsent(listName, k -> new ReentrantLock());
-        Condition condition = conditions.computeIfAbsent(listName, k -> lock.newCondition());
+        ReentrantLock lock = lockManager.getLock(listName);
+        Condition condition = conditionManager.getCondition(listName, lock);
 
         List<String> reversed = new ArrayList<>(values);
         Collections.reverse(reversed);
@@ -41,8 +41,8 @@ public class ListValueStore implements IListValueStore {
 
     @Override
     public Integer rightAdd(String listName, List<String> values) {
-        ReentrantLock lock = locks.computeIfAbsent(listName, k -> new ReentrantLock());
-        Condition condition = conditions.computeIfAbsent(listName, k -> lock.newCondition());
+        ReentrantLock lock = lockManager.getLock(listName);
+        Condition condition = conditionManager.getCondition(listName, lock);
 
         lock.lock();
 
@@ -60,8 +60,8 @@ public class ListValueStore implements IListValueStore {
     }
 
     @Override
-    public List<String> leftPop(String listName, Integer repetations) {
-        ReentrantLock lock = locks.get(listName);
+    public List<String> leftPop(String listName, Integer repetitions) {
+        ReentrantLock lock = lockManager.getAlreadyPresentLock(listName);
 
         if(lock == null) return null;
 
@@ -72,7 +72,7 @@ public class ListValueStore implements IListValueStore {
 
             if (list == null || list.isEmpty()) return null;
 
-            int n = Math.min(repetations, list.size());
+            int n = Math.min(repetitions, list.size());
             List<String> removed = new ArrayList<>(list.subList(0, n));
 
             list.subList(0, n).clear();
@@ -87,8 +87,8 @@ public class ListValueStore implements IListValueStore {
 
     @Override
     public List<String> blockingLeftPop(String listName, Float seconds) throws InterruptedException {
-        ReentrantLock lock = locks.computeIfAbsent(listName, k -> new ReentrantLock());
-        Condition condition = conditions.computeIfAbsent(listName, k -> lock.newCondition());
+        ReentrantLock lock = lockManager.getLock(listName);
+        Condition condition = conditionManager.getCondition(listName, lock);
 
         long nanos = seconds > 0 ? (long) (seconds * 1_000_000_000L) : 0;
 
@@ -120,7 +120,7 @@ public class ListValueStore implements IListValueStore {
 
     @Override
     public List<String> get(String listName, Integer startIndex, Integer endIndex) {
-        ReentrantLock lock = locks.get(listName);
+        ReentrantLock lock = lockManager.getAlreadyPresentLock(listName);
 
         if(lock == null) return List.of();
 
@@ -160,7 +160,7 @@ public class ListValueStore implements IListValueStore {
 
     @Override
     public Integer getSize(String listName) {
-        ReentrantLock lock = locks.get(listName);
+        ReentrantLock lock = lockManager.getAlreadyPresentLock(listName);
 
         if(lock == null) return null;
 

--- a/src/main/java/org/perfect047/storage/listvalue/ListValueStore.java
+++ b/src/main/java/org/perfect047/storage/listvalue/ListValueStore.java
@@ -174,4 +174,9 @@ public class ListValueStore implements IListValueStore {
             lock.unlock();
         }
     }
+
+    @Override
+    public String type(String key) {
+        return store.get(key) != null ? "list" : null;
+    }
 }

--- a/src/main/java/org/perfect047/storage/listvalue/LockManager.java
+++ b/src/main/java/org/perfect047/storage/listvalue/LockManager.java
@@ -1,0 +1,48 @@
+package org.perfect047.storage.listvalue;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Manages locks for individual keys.
+ * Ensures thread-safe access to key data.
+ */
+public class LockManager {
+
+    private final ConcurrentMap<String, ReentrantLock> lockMap = new ConcurrentHashMap<>();
+
+    /**
+     * Gets or creates a lock for the given key.
+     * @param key The key to get the lock for
+     * @return The ReentrantLock for this key
+     */
+    public ReentrantLock getLock(String key) {
+        return lockMap.computeIfAbsent(key, k -> new ReentrantLock());
+    }
+
+    /**
+     * Checks if a lock exists for the given key.
+     * @param key The key to check
+     * @return lock if a lock exists, null otherwise
+     */
+    public ReentrantLock getAlreadyPresentLock(String key) {
+        return lockMap.get(key);
+    }
+
+    /**
+     * Removes the lock for a key (should only be called when key is deleted).
+     * @param key The key to remove the lock for
+     */
+    public void removeLock(String key) {
+        lockMap.remove(key);
+    }
+
+    /**
+     * Clears all locks.
+     */
+    public void clear() {
+        lockMap.clear();
+    }
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/IBlockingStreamReader.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/IBlockingStreamReader.java
@@ -1,0 +1,11 @@
+package org.perfect047.storage.streamvalue;
+
+import java.util.List;
+
+/**
+ * Interface for blocking stream read operations.
+ * Segregated responsibility: only handles blocking/concurrent read operations.
+ */
+public interface IBlockingStreamReader {
+    List<Object> readBlocking(String listName, String startId, long timeoutMs);
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/IStreamReader.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/IStreamReader.java
@@ -1,0 +1,13 @@
+package org.perfect047.storage.streamvalue;
+
+import java.util.List;
+
+/**
+ * Interface for non-blocking stream read operations.
+ * Segregated responsibility: only handles non-blocking/concurrent read operations.
+ */
+public interface IStreamReader {
+    List<Object> read(String listName, String startId);
+    List<Object> range(String listName, String start, String end);
+    String getLastId(String listName);
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/IStreamValueStore.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/IStreamValueStore.java
@@ -1,4 +1,6 @@
 package org.perfect047.storage.streamvalue;
 
-public interface IStreamValueStore extends IStreamWriter, IStreamReader, IBlockingStreamReader {
+import org.perfect047.storage.ITypeStore;
+
+public interface IStreamValueStore extends IStreamWriter, IStreamReader, IBlockingStreamReader, ITypeStore {
 }

--- a/src/main/java/org/perfect047/storage/streamvalue/IStreamValueStore.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/IStreamValueStore.java
@@ -1,0 +1,4 @@
+package org.perfect047.storage.streamvalue;
+
+public interface IStreamValueStore extends IStreamWriter, IStreamReader, IBlockingStreamReader {
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/IStreamWriter.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/IStreamWriter.java
@@ -1,0 +1,7 @@
+package org.perfect047.storage.streamvalue;
+
+import java.util.List;
+
+public interface IStreamWriter {
+    String add(String listName, List<String> args);
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/LockEntry.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/LockEntry.java
@@ -1,0 +1,9 @@
+package org.perfect047.storage.streamvalue;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+class LockEntry {
+    final ReentrantLock lock = new ReentrantLock();
+    final Condition condition = lock.newCondition();
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/LockManager.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/LockManager.java
@@ -1,0 +1,40 @@
+package org.perfect047.storage.streamvalue;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Manages locks for individual keys.
+ * Ensures thread-safe access to key data.
+ */
+public class LockManager {
+
+    private final ConcurrentMap<String, LockEntry> lockMap = new ConcurrentHashMap<>();
+
+    /**
+     * Gets or creates a lock for the given key.
+     * @param key The key to get the lock for
+     * @return The LockEntry for this key
+     */
+    public LockEntry getLockEntry(String key) {
+        return lockMap.computeIfAbsent(key, k -> new LockEntry());
+    }
+
+    /**
+     * Removes the lock for a key (should only be called when key is deleted).
+     * @param key The key to remove the lock for
+     */
+    public void remove(String key) {
+        lockMap.remove(key);
+    }
+
+    /**
+     * Clears all locks.
+     */
+    public void clear() {
+        lockMap.clear();
+    }
+}
+

--- a/src/main/java/org/perfect047/storage/streamvalue/StreamValueStore.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/StreamValueStore.java
@@ -207,4 +207,8 @@ public class StreamValueStore implements IStreamValueStore{
         }
     }
 
+    @Override
+    public String type(String key) {
+        return store.get(key) != null ? "stream" : null;
+    }
 }

--- a/src/main/java/org/perfect047/storage/streamvalue/StreamValueStore.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/StreamValueStore.java
@@ -128,8 +128,13 @@ public class StreamValueStore implements IStreamValueStore{
         IdCursor startCursor = IdCursor.parseStart(start);
         IdCursor endCursor = IdCursor.parseEnd(end);
 
-        NavigableMap<Long, Deque<Map<String, String>>> subMap =
-                timeMap.subMap(startCursor.ms, true, endCursor.ms, true);
+        NavigableMap<Long, Deque<Map<String, String>>> subMap;
+
+        try {
+            subMap = timeMap.subMap(startCursor.ms, true, endCursor.ms, true);
+        } catch (IllegalArgumentException e) {
+            return List.of();
+        }
 
         List<Object> result = new ArrayList<>();
 
@@ -201,7 +206,7 @@ public class StreamValueStore implements IStreamValueStore{
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            return null;
+            return List.of();
         } finally {
             lockEntry.lock.unlock();
         }

--- a/src/main/java/org/perfect047/storage/streamvalue/StreamValueStore.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/StreamValueStore.java
@@ -1,0 +1,210 @@
+package org.perfect047.storage.streamvalue;
+
+import org.perfect047.storage.streamvalue.cursor.IdCursor;
+import org.perfect047.storage.streamvalue.entry.StreamEntryBuilder;
+import org.perfect047.storage.streamvalue.idgenerator.IStreamIdGenerator;
+import org.perfect047.storage.streamvalue.idgenerator.StreamIdGeneratorFactory;
+import org.perfect047.storage.streamvalue.formatter.StreamEntryFormatter;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.logging.Logger;
+
+public class StreamValueStore implements IStreamValueStore{
+
+    private static final Logger LOGGER = Logger.getLogger(StreamValueStore.class.getName());
+    private final ConcurrentMap<String, ConcurrentSkipListMap<Long, Deque<Map<String, String>>>> store = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Long> lastMsMap = new ConcurrentHashMap<>();
+    private final LockManager lockManager = new LockManager();
+    private final IStreamIdGenerator idGenerator = StreamIdGeneratorFactory.getStreamIdGenerator();
+
+
+    @Override
+    public String add(String streamName, List<String> args) {
+
+        LockEntry lockEntry = lockManager.getLockEntry(streamName);
+
+        lockEntry.lock.lock();
+        try {
+            ConcurrentSkipListMap<Long, Deque<Map<String, String>>> timeMap =
+                    store.computeIfAbsent(streamName,
+                            k -> new ConcurrentSkipListMap<>());
+
+            // generator now returns IdCursor
+            IdCursor idCursor = idGenerator.generate(
+                    streamName,
+                    args,
+                    lastMsMap,
+                    store
+            );
+
+            Deque<Map<String, String>> deque =
+                    timeMap.computeIfAbsent(idCursor.ms,
+                            k -> new ConcurrentLinkedDeque<>());
+
+            Map<String, String> entry =
+                    StreamEntryBuilder.build(idCursor.toId(), args);
+
+            deque.addLast(entry);
+
+            lastMsMap.put(streamName, idCursor.ms);
+
+            lockEntry.condition.signalAll();
+
+            return idCursor.toId();
+
+        } finally {
+            lockEntry.lock.unlock();
+        }
+    }
+
+    @Override
+    public List<Object> read(String streamName, String startId) {
+
+        ConcurrentSkipListMap<Long, Deque<Map<String, String>>> timeMap =
+                store.get(streamName);
+
+        if (timeMap == null || timeMap.isEmpty()) {
+            return List.of();
+        }
+
+        IdCursor cursor = IdCursor.parse(startId);
+
+        // fast-path
+        Map.Entry<Long, Deque<Map<String, String>>> last = timeMap.lastEntry();
+        if (last != null) {
+            Map<String, String> lastEntry = last.getValue().peekLast();
+            if (lastEntry != null) {
+                IdCursor lastId = IdCursor.parse(lastEntry.get("id"));
+
+                if (lastId.ms < cursor.ms ||
+                        (lastId.ms == cursor.ms && lastId.seq <= cursor.seq)) {
+                    return List.of();
+                }
+            }
+        }
+
+        List<Object> result = new ArrayList<>();
+
+        // 1. same timestamp bucket
+        Deque<Map<String, String>> sameBucket = timeMap.get(cursor.ms);
+        if (sameBucket != null) {
+            for (Map<String, String> entry : sameBucket) {
+                IdCursor entryId = IdCursor.parse(entry.get("id"));
+
+                if (entryId.seq > cursor.seq) {
+                    result.add(StreamEntryFormatter.format(entry));
+                }
+            }
+        }
+
+        // 2. future timestamps
+        NavigableMap<Long, Deque<Map<String, String>>> tail =
+                timeMap.tailMap(cursor.ms, false);
+
+        for (Deque<Map<String, String>> bucket : tail.values()) {
+            for (Map<String, String> entry : bucket) {
+                result.add(StreamEntryFormatter.format(entry));
+            }
+        }
+
+        return result;
+    }
+
+
+    @Override
+    public List<Object> range(String streamName, String start, String end) {
+
+        ConcurrentSkipListMap<Long, Deque<Map<String, String>>> timeMap =
+                store.get(streamName);
+
+        if (timeMap == null || timeMap.isEmpty()) {
+            return List.of();
+        }
+
+        IdCursor startCursor = IdCursor.parseStart(start);
+        IdCursor endCursor = IdCursor.parseEnd(end);
+
+        NavigableMap<Long, Deque<Map<String, String>>> subMap =
+                timeMap.subMap(startCursor.ms, true, endCursor.ms, true);
+
+        List<Object> result = new ArrayList<>();
+
+        for (Map.Entry<Long, Deque<Map<String, String>>> bucket : subMap.entrySet()) {
+
+            long ms = bucket.getKey();
+
+            for (Map<String, String> entry : bucket.getValue()) {
+
+                IdCursor entryId = IdCursor.parse(entry.get("id"));
+
+                boolean afterStart =
+                        (ms > startCursor.ms) ||
+                                (ms == startCursor.ms && entryId.seq >= startCursor.seq);
+
+                boolean beforeEnd =
+                        (ms < endCursor.ms) ||
+                                (ms == endCursor.ms && entryId.seq <= endCursor.seq);
+
+                if (!afterStart || !beforeEnd) continue;
+
+                result.add(StreamEntryFormatter.format(entry));
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public String getLastId(String streamName) {
+
+        ConcurrentSkipListMap<Long, Deque<Map<String, String>>> timeMap =
+                store.get(streamName);
+
+        if (timeMap == null || timeMap.isEmpty()) return null;
+
+        Deque<Map<String, String>> deque = timeMap.lastEntry().getValue();
+        if (deque == null || deque.isEmpty()) return null;
+
+        Map<String, String> last = deque.peekLast();
+        return last != null ? last.get("id") : null;
+    }
+
+    @Override
+    public List<Object> readBlocking(String streamName, String startId, long timeoutMs) {
+
+        LockEntry lockEntry = lockManager.getLockEntry(streamName);
+
+        long nanos = timeoutMs > 0
+                ? java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+                : 0;
+
+        lockEntry.lock.lock();
+        try {
+            while (true) {
+
+                List<Object> result = read(streamName, startId);
+                if (result != null && !result.isEmpty()) {
+                    return result;
+                }
+
+                if (timeoutMs == 0) {
+                    lockEntry.condition.await();
+                } else {
+                    if (nanos <= 0) return null;
+                    nanos = lockEntry.condition.awaitNanos(nanos);
+                }
+            }
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } finally {
+            lockEntry.lock.unlock();
+        }
+    }
+
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/cursor/IdCursor.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/cursor/IdCursor.java
@@ -1,0 +1,50 @@
+package org.perfect047.storage.streamvalue.cursor;
+
+public final class IdCursor {
+
+    public final long ms;
+    public final long seq;
+
+    private IdCursor(long ms, long seq) {
+        this.ms = ms;
+        this.seq = seq;
+    }
+
+    public static IdCursor of(long ms, long seq) {
+        return new IdCursor(ms, seq);
+    }
+
+    public static IdCursor parse(String id) {
+        int dash = id.indexOf('-');
+        if (dash == -1) {
+            return new IdCursor(Long.parseLong(id), 0);
+        }
+        return new IdCursor(
+                Long.parseLong(id.substring(0, dash)),
+                Long.parseLong(id.substring(dash + 1))
+        );
+    }
+
+    public String toId() {
+        return ms + "-" + seq;
+    }
+
+    public static IdCursor parseStart(String start) {
+        if ("-".equals(start)) {
+            return new IdCursor(Long.MIN_VALUE, 0);
+        }
+        return parse(start);
+    }
+
+    public static IdCursor parseEnd(String end) {
+        if ("+".equals(end)) {
+            return new IdCursor(Long.MAX_VALUE, Long.MAX_VALUE);
+        }
+
+        if (!end.contains("-")) {
+            return new IdCursor(Long.parseLong(end), Long.MAX_VALUE);
+        }
+
+        return parse(end);
+    }
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/entry/StreamEntry.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/entry/StreamEntry.java
@@ -1,0 +1,24 @@
+package org.perfect047.storage.streamvalue.entry;
+
+import org.perfect047.storage.streamvalue.cursor.IdCursor;
+
+import java.util.Map;
+
+public final class StreamEntry {
+
+    private final IdCursor id;
+    private final Map<String, String> fields;
+
+    public StreamEntry(IdCursor id, Map<String, String> fields) {
+        this.id = id;
+        this.fields = fields;
+    }
+
+    public IdCursor getId() {
+        return id;
+    }
+
+    public Map<String, String> getFields() {
+        return fields;
+    }
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/entry/StreamEntryBuilder.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/entry/StreamEntryBuilder.java
@@ -1,0 +1,24 @@
+package org.perfect047.storage.streamvalue.entry;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class StreamEntryBuilder {
+
+    private StreamEntryBuilder() {}
+
+    public static Map<String, String> build(String id, List<String> args) {
+
+        Map<String, String> entry =
+                new LinkedHashMap<>(args.size() / 2 + 1);
+
+        entry.put("id", id);
+
+        for (int i = 1; i < args.size(); i += 2) {
+            entry.put(args.get(i), args.get(i + 1));
+        }
+
+        return entry;
+    }
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/formatter/StreamEntryFormatter.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/formatter/StreamEntryFormatter.java
@@ -1,0 +1,26 @@
+package org.perfect047.storage.streamvalue.formatter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public final class StreamEntryFormatter {
+
+    private StreamEntryFormatter() {}
+
+    public static List<Object> format(Map<String, String> entry) {
+
+        String id = entry.get("id");
+
+        List<String> kv = new ArrayList<>(entry.size() * 2);
+
+        for (Map.Entry<String, String> kvEntry : entry.entrySet()) {
+            if (!kvEntry.getKey().equals("id")) {
+                kv.add(kvEntry.getKey());
+                kv.add(kvEntry.getValue());
+            }
+        }
+
+        return List.of(id, kv);
+    }
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/idgenerator/DefaultStreamIdGenerator.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/idgenerator/DefaultStreamIdGenerator.java
@@ -74,12 +74,12 @@ public class DefaultStreamIdGenerator implements IStreamIdGenerator {
             ConcurrentMap<String, Long> lastMsMap) {
 
         if (cursor.ms == 0 && cursor.seq == 0) {
-            throw new RuntimeException("ERR The ID specified in XADD must be greater than 0-0");
+            throw new IllegalArgumentException("ERR The ID specified in XADD must be greater than 0-0");
         }
 
         Long lastMs = lastMsMap.get(streamName);
         if (lastMs != null && cursor.ms < lastMs) {
-            throw new RuntimeException("ERR The ID specified in XADD is equal or smaller than the target stream top item");
+            throw new IllegalArgumentException("ERR The ID specified in XADD is equal or smaller than the target stream top item");
         }
     }
 
@@ -102,7 +102,7 @@ public class DefaultStreamIdGenerator implements IStreamIdGenerator {
         if (lastEntry != null) {
             long lastSeq = extractLastSeq(lastEntry);
             if (newSeq <= lastSeq) {
-                throw new RuntimeException("ERR The ID specified in XADD is equal or smaller than the target stream top item");
+                throw new IllegalArgumentException("ERR The ID specified in XADD is equal or smaller than the target stream top item");
             }
         }
 

--- a/src/main/java/org/perfect047/storage/streamvalue/idgenerator/DefaultStreamIdGenerator.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/idgenerator/DefaultStreamIdGenerator.java
@@ -74,12 +74,12 @@ public class DefaultStreamIdGenerator implements IStreamIdGenerator {
             ConcurrentMap<String, Long> lastMsMap) {
 
         if (cursor.ms == 0 && cursor.seq == 0) {
-            throw new RuntimeException("ERR ID must be greater than 0-0");
+            throw new RuntimeException("ERR The ID specified in XADD must be greater than 0-0");
         }
 
         Long lastMs = lastMsMap.get(streamName);
         if (lastMs != null && cursor.ms < lastMs) {
-            throw new RuntimeException("ERR ID is smaller than stream top item");
+            throw new RuntimeException("ERR The ID specified in XADD is equal or smaller than the target stream top item");
         }
     }
 
@@ -102,7 +102,7 @@ public class DefaultStreamIdGenerator implements IStreamIdGenerator {
         if (lastEntry != null) {
             long lastSeq = extractLastSeq(lastEntry);
             if (newSeq <= lastSeq) {
-                throw new RuntimeException("ERR sequence not increasing");
+                throw new RuntimeException("ERR The ID specified in XADD is equal or smaller than the target stream top item");
             }
         }
 

--- a/src/main/java/org/perfect047/storage/streamvalue/idgenerator/DefaultStreamIdGenerator.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/idgenerator/DefaultStreamIdGenerator.java
@@ -1,0 +1,120 @@
+package org.perfect047.storage.streamvalue.idgenerator;
+
+import org.perfect047.storage.streamvalue.cursor.IdCursor;
+
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+public class DefaultStreamIdGenerator implements IStreamIdGenerator {
+
+    @Override
+    public IdCursor generate(
+            String streamName,
+            List<String> args,
+            ConcurrentMap<String, Long> lastMsMap,
+            ConcurrentMap<String, ConcurrentSkipListMap<Long, Deque<Map<String, String>>>> store) {
+
+        String inputId = args.get(0);
+
+        ConcurrentSkipListMap<Long, Deque<Map<String, String>>> timeMap =
+                store.computeIfAbsent(streamName, k -> new ConcurrentSkipListMap<>());
+
+        if ("*".equals(inputId)) {
+            return generateAutoId(streamName, lastMsMap, timeMap);
+        } else {
+            return generateCustomId(streamName, inputId, timeMap, lastMsMap);
+        }
+    }
+
+    private IdCursor generateAutoId(
+            String streamName,
+            ConcurrentMap<String, Long> lastMsMap,
+            ConcurrentSkipListMap<Long, Deque<Map<String, String>>> timeMap) {
+
+        long newMs = System.currentTimeMillis();
+        Long lastMs = lastMsMap.get(streamName);
+
+        if (lastMs != null && newMs < lastMs) {
+            newMs = lastMs;
+        }
+
+        Deque<Map<String, String>> deque =
+                timeMap.computeIfAbsent(newMs, k -> new ConcurrentLinkedDeque<>());
+
+        long newSeq = extractNextSeq(deque);
+
+        return IdCursor.of(newMs, newSeq);
+    }
+
+    private IdCursor generateCustomId(
+            String streamName,
+            String inputId,
+            ConcurrentSkipListMap<Long, Deque<Map<String, String>>> timeMap,
+            ConcurrentMap<String, Long> lastMsMap) {
+
+        IdCursor parsed = IdCursor.parse(inputId);
+
+        validateCustomId(streamName, parsed, lastMsMap);
+
+        Deque<Map<String, String>> deque =
+                timeMap.computeIfAbsent(parsed.ms, k -> new ConcurrentLinkedDeque<>());
+
+        long newSeq = resolveSequence(inputId, parsed, deque);
+
+        return IdCursor.of(parsed.ms, newSeq);
+    }
+
+    private void validateCustomId(
+            String streamName,
+            IdCursor cursor,
+            ConcurrentMap<String, Long> lastMsMap) {
+
+        if (cursor.ms == 0 && cursor.seq == 0) {
+            throw new RuntimeException("ERR ID must be greater than 0-0");
+        }
+
+        Long lastMs = lastMsMap.get(streamName);
+        if (lastMs != null && cursor.ms < lastMs) {
+            throw new RuntimeException("ERR ID is smaller than stream top item");
+        }
+    }
+
+    private long resolveSequence(
+            String rawInput,
+            IdCursor parsed,
+            Deque<Map<String, String>> deque) {
+
+        Map<String, String> lastEntry = deque.peekLast();
+
+        // handle "*"
+        if (rawInput.endsWith("-*")) {
+            return (lastEntry == null)
+                    ? (parsed.ms == 0 ? 1 : 0)
+                    : extractNextSeq(deque);
+        }
+
+        long newSeq = parsed.seq;
+
+        if (lastEntry != null) {
+            long lastSeq = extractLastSeq(lastEntry);
+            if (newSeq <= lastSeq) {
+                throw new RuntimeException("ERR sequence not increasing");
+            }
+        }
+
+        return newSeq;
+    }
+
+    private long extractNextSeq(Deque<Map<String, String>> deque) {
+        Map<String, String> lastEntry = deque.peekLast();
+        return (lastEntry == null) ? 0 : extractLastSeq(lastEntry) + 1;
+    }
+
+    private long extractLastSeq(Map<String, String> entry) {
+        return IdCursor.parse(entry.get("id")).seq;
+    }
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/idgenerator/IStreamIdGenerator.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/idgenerator/IStreamIdGenerator.java
@@ -1,0 +1,18 @@
+package org.perfect047.storage.streamvalue.idgenerator;
+
+import org.perfect047.storage.streamvalue.cursor.IdCursor;
+
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+public interface IStreamIdGenerator {
+    IdCursor generate(
+            String streamName,
+            List<String> args,
+            ConcurrentMap<String, Long> lastMsMap,
+            ConcurrentMap<String, ConcurrentSkipListMap<Long, Deque<Map<String, String>>>> store
+    );
+}

--- a/src/main/java/org/perfect047/storage/streamvalue/idgenerator/StreamIdGeneratorFactory.java
+++ b/src/main/java/org/perfect047/storage/streamvalue/idgenerator/StreamIdGeneratorFactory.java
@@ -1,0 +1,13 @@
+package org.perfect047.storage.streamvalue.idgenerator;
+
+public class StreamIdGeneratorFactory {
+    private static final IStreamIdGenerator streamIdGenerator;
+
+    static{
+        streamIdGenerator = new DefaultStreamIdGenerator();
+    }
+
+    public static IStreamIdGenerator getStreamIdGenerator(){
+        return streamIdGenerator;
+    }
+}

--- a/src/main/java/org/perfect047/util/RespString.java
+++ b/src/main/java/org/perfect047/util/RespString.java
@@ -42,18 +42,50 @@ public class RespString {
         return sb.toString();
     }
 
-    public static String getRespArrayString(List<String> values) {
+    public static String getRespArrayString(List<?> values) {
         StringBuilder sb = new StringBuilder();
 
         if (values == null) return "*-1\r\n";
 
         sb.append("*").append(values.size()).append("\r\n");
 
-        for (String value : values) {
-            sb.append("$").append(value.length()).append("\r\n").append(value).append("\r\n");
+        for (Object value : values) {
+
+            if (value instanceof List<?>) {
+                sb.append(getRespArrayString((List<?>) value));
+            }
+
+            else if (value instanceof String str) {
+                sb.append("$")
+                        .append(str.length())
+                        .append("\r\n")
+                        .append(str)
+                        .append("\r\n");
+            }
+
+            else if (value instanceof Integer i) {
+                sb.append(":").append(i).append("\r\n");
+            }
+
+            else if (value == null) {
+                sb.append("$-1\r\n");
+            }
+
+            else {
+                String str = value.toString();
+                sb.append("$")
+                        .append(str.length())
+                        .append("\r\n")
+                        .append(str)
+                        .append("\r\n");
+            }
         }
 
         return sb.toString();
+    }
+
+    public static String getRespErrorString(String err) {
+        return "-" + err + "\r\n";
     }
 
 }

--- a/src/test/java/org/perfect047/benchmark/ZappyDbBenchmark.java
+++ b/src/test/java/org/perfect047/benchmark/ZappyDbBenchmark.java
@@ -2,7 +2,7 @@ package org.perfect047.benchmark;
 
 import org.perfect047.command.CommandFactory;
 import org.perfect047.command.ICommand;
-import org.perfect047.storage.keyvalue.KeyValueKeyValueStore;
+import org.perfect047.storage.keyvalue.KeyValueStore;
 import org.perfect047.storage.listvalue.ListValueStore;
 import org.perfect047.util.EnvLoader;
 
@@ -664,7 +664,7 @@ public final class ZappyDbBenchmark {
     }
 
     private static final class LocalBenchmarkEnvironment implements BenchmarkEnvironment {
-        private final KeyValueKeyValueStore keyValueStore = new KeyValueKeyValueStore();
+        private final KeyValueStore keyValueStore = new KeyValueStore();
         private final ListValueStore listValueStore = new ListValueStore();
         private final CommandFactory commandFactory = new CommandFactory(keyValueStore, listValueStore);
 

--- a/src/test/java/org/perfect047/benchmark/ZappyDbBenchmark.java
+++ b/src/test/java/org/perfect047/benchmark/ZappyDbBenchmark.java
@@ -4,6 +4,8 @@ import org.perfect047.command.CommandFactory;
 import org.perfect047.command.ICommand;
 import org.perfect047.storage.keyvalue.KeyValueStore;
 import org.perfect047.storage.listvalue.ListValueStore;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.storage.streamvalue.StreamValueStore;
 import org.perfect047.util.EnvLoader;
 
 import java.io.BufferedInputStream;
@@ -666,7 +668,8 @@ public final class ZappyDbBenchmark {
     private static final class LocalBenchmarkEnvironment implements BenchmarkEnvironment {
         private final KeyValueStore keyValueStore = new KeyValueStore();
         private final ListValueStore listValueStore = new ListValueStore();
-        private final CommandFactory commandFactory = new CommandFactory(keyValueStore, listValueStore);
+        private final IStreamValueStore streamValueStore = new StreamValueStore();
+        private final CommandFactory commandFactory = new CommandFactory(keyValueStore, listValueStore, streamValueStore);
 
         @Override
         public void seed(BenchmarkConfig config) {

--- a/src/test/java/org/perfect047/command/GetCommandTest.java
+++ b/src/test/java/org/perfect047/command/GetCommandTest.java
@@ -2,7 +2,7 @@ package org.perfect047.command;
 
 import org.junit.jupiter.api.Test;
 import org.perfect047.storage.keyvalue.IKeyValueStore;
-import org.perfect047.storage.keyvalue.KeyValueKeyValueStore;
+import org.perfect047.storage.keyvalue.KeyValueStore;
 import org.perfect047.util.RespString;
 
 import java.io.ByteArrayOutputStream;
@@ -17,7 +17,7 @@ public class GetCommandTest {
     public void testGetCommand() throws Exception {
         String key = "test_key_" + UUID.randomUUID();
         String value = "test_value";
-        IKeyValueStore keyValueStore = new KeyValueKeyValueStore();
+        IKeyValueStore keyValueStore = new KeyValueStore();
 
         // Set a value first
         keyValueStore.set(key, value, null);
@@ -34,7 +34,7 @@ public class GetCommandTest {
     @Test
     public void testGetCommandNonExistentKey() throws Exception {
         String key = "non_existent_" + UUID.randomUUID();
-        IKeyValueStore keyValueStore = new KeyValueKeyValueStore();
+        IKeyValueStore keyValueStore = new KeyValueStore();
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         GetCommand getCommand = new GetCommand(outputStream, keyValueStore);

--- a/src/test/java/org/perfect047/command/SetCommandTest.java
+++ b/src/test/java/org/perfect047/command/SetCommandTest.java
@@ -2,7 +2,7 @@ package org.perfect047.command;
 
 import org.junit.jupiter.api.Test;
 import org.perfect047.storage.keyvalue.IKeyValueStore;
-import org.perfect047.storage.keyvalue.KeyValueKeyValueStore;
+import org.perfect047.storage.keyvalue.KeyValueStore;
 import org.perfect047.util.RespString;
 
 import java.io.ByteArrayOutputStream;
@@ -16,7 +16,7 @@ public class SetCommandTest {
     @Test
     public void testSetCommand() throws Exception {
         String key = "test_key_" + UUID.randomUUID();
-        IKeyValueStore keyValueStore = new KeyValueKeyValueStore();
+        IKeyValueStore keyValueStore = new KeyValueStore();
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         SetCommand setCommand = new SetCommand(outputStream, keyValueStore);
 

--- a/src/test/java/org/perfect047/command/TypeCommandTest.java
+++ b/src/test/java/org/perfect047/command/TypeCommandTest.java
@@ -1,0 +1,105 @@
+package org.perfect047.command;
+
+import org.junit.jupiter.api.Test;
+import org.perfect047.storage.keyvalue.IKeyValueStore;
+import org.perfect047.storage.keyvalue.KeyValueStore;
+import org.perfect047.storage.listvalue.IListValueStore;
+import org.perfect047.storage.listvalue.ListValueStore;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.storage.streamvalue.StreamValueStore;
+import org.perfect047.util.RespString;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TypeCommandTest {
+
+    @Test
+    public void testTypeCommandKeyValue() throws Exception {
+        String key = "test_key_" + UUID.randomUUID();
+        String value = "test_value";
+        IKeyValueStore keyValueStore = new KeyValueStore();
+        IListValueStore listValueStore = new ListValueStore();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+
+        keyValueStore.set(key, value, null);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        TypeCommand typeCommand = new TypeCommand(outputStream, streamValueStore, keyValueStore, listValueStore);
+
+        typeCommand.execute(List.of("TYPE", key));
+
+        String expected = RespString.getRespSimpleString(List.of("string"));
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testTypeCommandListValue() throws Exception {
+        String key = "test_list_key_" + UUID.randomUUID();
+        IKeyValueStore keyValueStore = new KeyValueStore();
+        IListValueStore listValueStore = new ListValueStore();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+
+        listValueStore.leftAdd(key, List.of("item1", "item2"));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        TypeCommand typeCommand = new TypeCommand(outputStream, streamValueStore, keyValueStore, listValueStore);
+
+        typeCommand.execute(List.of("TYPE", key));
+
+        String expected = RespString.getRespSimpleString(List.of("list"));
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testTypeCommandStreamValue() throws Exception {
+        String key = "test_stream_key_" + UUID.randomUUID();
+        IKeyValueStore keyValueStore = new KeyValueStore();
+        IListValueStore listValueStore = new ListValueStore();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+
+        streamValueStore.add(key, List.of("0-1", "field1", "value1"));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        TypeCommand typeCommand = new TypeCommand(outputStream, streamValueStore, keyValueStore, listValueStore);
+
+        typeCommand.execute(List.of("TYPE", key));
+
+        String expected = RespString.getRespSimpleString(List.of("stream"));
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testTypeCommandNonExistentKey() throws Exception {
+        String key = "non_existent_" + UUID.randomUUID();
+        IKeyValueStore keyValueStore = new KeyValueStore();
+        IListValueStore listValueStore = new ListValueStore();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        TypeCommand typeCommand = new TypeCommand(outputStream, streamValueStore, keyValueStore, listValueStore);
+
+        typeCommand.execute(List.of("TYPE", key));
+
+        String expected = RespString.getRespSimpleString(List.of("none"));
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testTypeCommandMissingKeyArgument() {
+        IKeyValueStore keyValueStore = new KeyValueStore();
+        IListValueStore listValueStore = new ListValueStore();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        TypeCommand typeCommand = new TypeCommand(outputStream, streamValueStore, keyValueStore, listValueStore);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            typeCommand.execute(List.of("TYPE"));
+        });
+    }
+}

--- a/src/test/java/org/perfect047/command/XAddCommandTest.java
+++ b/src/test/java/org/perfect047/command/XAddCommandTest.java
@@ -1,0 +1,108 @@
+package org.perfect047.command;
+
+import org.junit.jupiter.api.Test;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.storage.streamvalue.StreamValueStore;
+import org.perfect047.util.RespString;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class XAddCommandTest {
+
+    @Test
+    public void testXAddCommand() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XAddCommand xAddCommand = new XAddCommand(outputStream, streamValueStore);
+
+        List<String> args = List.of("XADD", streamName, "*", "field1", "value1", "field2", "value2");
+        xAddCommand.execute(args);
+
+        String response = outputStream.toString();
+        assertTrue(response.startsWith("$")); // Bulk string response
+        assertTrue(response.contains("-")); // ID should contain a hyphen
+        outputStream.reset();
+
+        // Verify the entry was added
+        List<Object> rangeResult = streamValueStore.range(streamName, "-", "+");
+        assertEquals(1, rangeResult.size());
+        List<Object> entry = (List<Object>) rangeResult.get(0);
+        assertEquals(2, entry.size()); // ID and fields
+        List<String> fields = (List<String>) entry.get(1);
+        assertEquals(4, fields.size()); // field1, value1, field2, value2
+        assertEquals("field1", fields.get(0));
+        assertEquals("value1", fields.get(1));
+        assertEquals("field2", fields.get(2));
+        assertEquals("value2", fields.get(3));
+    }
+
+    @Test
+    public void testXAddCommandWithSpecificId() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XAddCommand xAddCommand = new XAddCommand(outputStream, streamValueStore);
+
+        String specificId = "1-0";
+        List<String> args = List.of("XADD", streamName, specificId, "field1", "value1");
+        xAddCommand.execute(args);
+
+        String expected = RespString.getRespBulkString(List.of(specificId));
+        assertEquals(expected, outputStream.toString());
+        outputStream.reset();
+
+        // Verify the entry was added
+        List<Object> rangeResult = streamValueStore.range(streamName, "-", "+");
+        assertEquals(1, rangeResult.size());
+        List<Object> entry = (List<Object>) rangeResult.get(0);
+        assertEquals(specificId, entry.get(0));
+    }
+
+    @Test
+    public void testXAddCommandInvalidArgumentsCount() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XAddCommand xAddCommand = new XAddCommand(outputStream, streamValueStore);
+
+        List<String> args = List.of("XADD", streamName, "*"); // Missing field-value pairs
+        xAddCommand.execute(args);
+
+        String expectedError = RespString.getRespErrorString("XADD requires key, id and at least one field-value pair");
+        assertEquals(expectedError, outputStream.toString());
+    }
+
+    @Test
+    public void testXAddCommandOddNumberOfFieldValues() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XAddCommand xAddCommand = new XAddCommand(outputStream, streamValueStore);
+
+        List<String> args = List.of("XADD", streamName, "*", "field1", "value1", "field2"); // Odd number
+        xAddCommand.execute(args);
+
+        String expectedError = RespString.getRespErrorString("XADD field-value pairs must be even");
+        assertEquals(expectedError, outputStream.toString());
+    }
+
+    @Test
+    public void testXAddCommandWithZeroId() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XAddCommand xAddCommand = new XAddCommand(outputStream, streamValueStore);
+
+        List<String> args = List.of("XADD", streamName, "0-0", "field1", "value1");
+        xAddCommand.execute(args);
+
+        String expected = RespString.getRespErrorString("ERR The ID specified in XADD must be greater than 0-0");
+        assertEquals(expected, outputStream.toString());
+    }
+}

--- a/src/test/java/org/perfect047/command/XRangeCommandTest.java
+++ b/src/test/java/org/perfect047/command/XRangeCommandTest.java
@@ -1,0 +1,124 @@
+package org.perfect047.command;
+
+import org.junit.jupiter.api.Test;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.storage.streamvalue.StreamValueStore;
+import org.perfect047.util.RespString;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class XRangeCommandTest {
+
+    @Test
+    public void testXRangeCommandBasic() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XRangeCommand xRangeCommand = new XRangeCommand(outputStream, streamValueStore);
+
+        // Add some entries
+        streamValueStore.add(streamName, List.of("1-1", "field1", "value1"));
+        streamValueStore.add(streamName, List.of("1-2", "field2", "value2"));
+        streamValueStore.add(streamName, List.of("2-1", "field3", "value3"));
+
+        List<String> args = List.of("XRANGE", streamName, "1-1", "2-1");
+        xRangeCommand.execute(args);
+
+        List<Object> expectedResult = List.of(
+                List.of("1-1", List.of("field1", "value1")),
+                List.of("1-2", List.of("field2", "value2")),
+                List.of("2-1", List.of("field3", "value3"))
+        );
+        String expected = RespString.getRespArrayString(expectedResult);
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testXRangeCommandWithMinMaxIds() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XRangeCommand xRangeCommand = new XRangeCommand(outputStream, streamValueStore);
+
+        // Add some entries
+        streamValueStore.add(streamName, List.of("1-1", "field1", "value1"));
+        streamValueStore.add(streamName, List.of("1-2", "field2", "value2"));
+        streamValueStore.add(streamName, List.of("2-1", "field3", "value3"));
+
+        List<String> args = List.of("XRANGE", streamName, "-", "+");
+        xRangeCommand.execute(args);
+
+        List<Object> expectedResult = List.of(
+                List.of("1-1", List.of("field1", "value1")),
+                List.of("1-2", List.of("field2", "value2")),
+                List.of("2-1", List.of("field3", "value3"))
+        );
+        String expected = RespString.getRespArrayString(expectedResult);
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testXRangeCommandNonExistentStream() throws Exception {
+        String streamName = "non_existent_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XRangeCommand xRangeCommand = new XRangeCommand(outputStream, streamValueStore);
+
+        List<String> args = List.of("XRANGE", streamName, "-", "+");
+        xRangeCommand.execute(args);
+
+        String expected = RespString.getRespArrayString(List.of());
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testXRangeCommandEmptyStream() throws Exception {
+        String streamName = "empty_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XRangeCommand xRangeCommand = new XRangeCommand(outputStream, streamValueStore);
+
+        List<String> args = List.of("XRANGE", streamName, "-", "+");
+        xRangeCommand.execute(args);
+
+        String expected = RespString.getRespArrayString(List.of());
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testXRangeCommandInvalidRange() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XRangeCommand xRangeCommand = new XRangeCommand(outputStream, streamValueStore);
+
+        streamValueStore.add(streamName, List.of("10-1", "field1", "value1"));
+        streamValueStore.add(streamName, List.of("20-1", "field2", "value2"));
+
+        List<String> args = List.of("XRANGE", streamName, "30-1", "1-1"); // End before start
+        xRangeCommand.execute(args);
+
+        String expected = RespString.getRespArrayString(List.of());
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testXRangeCommandMissingArguments() {
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XRangeCommand xRangeCommand = new XRangeCommand(outputStream, streamValueStore);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            xRangeCommand.execute(List.of("XRANGE", "stream1", "1-1")); // Missing end
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            xRangeCommand.execute(List.of("XRANGE", "stream1")); // Missing start and end
+        });
+    }
+}

--- a/src/test/java/org/perfect047/command/XReadCommandTest.java
+++ b/src/test/java/org/perfect047/command/XReadCommandTest.java
@@ -1,0 +1,140 @@
+package org.perfect047.command;
+
+import org.junit.jupiter.api.Test;
+import org.perfect047.storage.streamvalue.IStreamValueStore;
+import org.perfect047.storage.streamvalue.StreamValueStore;
+import org.perfect047.util.RespString;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class XReadCommandTest {
+
+    @Test
+    public void testXReadCommandBasic() throws Exception {
+        String streamName1 = "test_stream_1_" + UUID.randomUUID();
+        String streamName2 = "test_stream_2_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XReadCommand xReadCommand = new XReadCommand(outputStream, streamValueStore);
+
+        // Add entries to stream1
+        streamValueStore.add(streamName1, List.of("1-1", "field1", "value1"));
+        streamValueStore.add(streamName1, List.of("1-2", "field2", "value2"));
+
+        // Add entries to stream2
+        streamValueStore.add(streamName2, List.of("2-1", "fieldA", "valueA"));
+
+        List<String> args = List.of("XREAD", "STREAMS", streamName1, streamName2, "0-0", "0-0");
+        xReadCommand.execute(args);
+
+        List<Object> expectedResult = List.of(
+                List.of(
+                        streamName1,
+                        List.of(
+                                List.of("1-1", List.of("field1", "value1")),
+                                List.of("1-2", List.of("field2", "value2"))
+                        )
+                ),
+                List.of(
+                        streamName2,
+                        List.of(
+                                List.of("2-1", List.of("fieldA", "valueA"))
+                        )
+                )
+        );
+        String expected = RespString.getRespArrayString(expectedResult);
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testXReadCommandWithDollarId() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XReadCommand xReadCommand = new XReadCommand(outputStream, streamValueStore);
+
+        // Add some entries
+        streamValueStore.add(streamName, List.of("1-1", "field1", "value1"));
+        String lastId = streamValueStore.add(streamName, List.of("*", "field2", "value2"));
+
+        List<String> args = List.of("XREAD", "STREAMS", streamName, "$");
+        xReadCommand.execute(args);
+
+        List<Object> expectedResult = List.of(
+                List.of(
+                        streamName,
+                        List.of(
+                                List.of(lastId, List.of("field2", "value2"))
+                        )
+                )
+        );
+        String expected = RespString.getRespArrayString(expectedResult);
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testXReadCommandWithBlock() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XReadCommand xReadCommand = new XReadCommand(outputStream, streamValueStore);
+
+        // Add an entry after a short delay to simulate blocking
+        final String[] generatedId = new String[1];
+
+        new Thread(() -> {
+            try {
+                Thread.sleep(100);
+                generatedId[0] = streamValueStore.add(streamName, List.of("*", "field1", "value1"));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }).start();
+
+        List<String> args = List.of("XREAD", "BLOCK", "500", "STREAMS", streamName, "$");
+        xReadCommand.execute(args);
+
+        List<Object> expectedResult = List.of(
+                List.of(
+                        streamName,
+                        List.of(
+                                List.of(generatedId[0], List.of("field1", "value1"))
+                        )
+                )
+        );
+
+        String expected = RespString.getRespArrayString(expectedResult);
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testXReadCommandWithBlockTimeout() throws Exception {
+        String streamName = "test_stream_" + UUID.randomUUID();
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XReadCommand xReadCommand = new XReadCommand(outputStream, streamValueStore);
+
+        List<String> args = List.of("XREAD", "BLOCK", "100", "STREAMS", streamName, "$");
+        xReadCommand.execute(args);
+
+        String expected = RespString.getRespArrayString(List.of()); // Should return empty array on timeout
+        assertEquals(expected, outputStream.toString());
+    }
+
+    @Test
+    public void testXReadCommandMissingStreamsKeyword() {
+        IStreamValueStore streamValueStore = new StreamValueStore();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        XReadCommand xReadCommand = new XReadCommand(outputStream, streamValueStore);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            xReadCommand.execute(List.of("XREAD", "test_stream", "0-0"));
+        });
+    }
+
+}


### PR DESCRIPTION
Issue: #7 

### **Acceptance Criteria**

* [x] `TYPE key` returns `stream` for stream keys
* [x] `XADD` supports full, partial, and explicit IDs
* [x] ID validation enforces ordering and format
* [x] Duplicate or out-of-order IDs are rejected
* [x] `XRANGE` supports `-`, `+`, and COUNT
* [x] `XREVRANGE` returns reverse-ordered results
* [x] `XREAD` supports:

  * single stream
  * multiple streams
* [x] `$` correctly reads only new entries
* [x] Blocking reads:

  * block when no data
  * unblock on new data
  * respect timeout
* [x] Non-existing stream handling is consistent (no crash)
